### PR TITLE
Discard master/slave jargon

### DIFF
--- a/venv/lib/python3.6/site-packages/boto/elastictranscoder/layer1.py
+++ b/venv/lib/python3.6/site-packages/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/venv/lib/python3.6/site-packages/boto/emr/connection.py
+++ b/venv/lib/python3.6/site-packages/boto/emr/connection.py
@@ -408,8 +408,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -436,11 +436,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -471,7 +471,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -526,15 +526,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -721,15 +721,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/venv/lib/python3.6/site-packages/boto/emr/step.py
+++ b/venv/lib/python3.6/site-packages/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/venv/lib/python3.6/site-packages/boto/kms/layer1.py
+++ b/venv/lib/python3.6/site-packages/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/venv/lib/python3.6/site-packages/boto/opsworks/layer1.py
+++ b/venv/lib/python3.6/site-packages/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/venv/lib/python3.6/site-packages/boto/pyami/bootstrap.py
+++ b/venv/lib/python3.6/site-packages/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/venv/lib/python3.6/site-packages/boto/rds/__init__.py
+++ b/venv/lib/python3.6/site-packages/boto/rds/__init__.py
@@ -138,8 +138,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -168,8 +168,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -222,8 +222,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -240,8 +240,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -398,8 +398,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -423,8 +423,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -562,7 +562,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -593,8 +593,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -680,8 +680,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/venv/lib/python3.6/site-packages/boto/rds/dbinstance.py
+++ b/venv/lib/python3.6/site-packages/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/venv/lib/python3.6/site-packages/boto/rds/dbsnapshot.py
+++ b/venv/lib/python3.6/site-packages/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/venv/lib/python3.6/site-packages/boto/rds2/layer1.py
+++ b/venv/lib/python3.6/site-packages/boto/rds2/layer1.py
@@ -321,8 +321,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -417,9 +417,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -452,8 +452,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -536,7 +536,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -656,8 +656,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2488,7 +2488,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2616,14 +2616,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2634,7 +2634,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2668,7 +2668,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2820,8 +2820,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/venv/lib/python3.6/site-packages/boto/redshift/layer1.py
+++ b/venv/lib/python3.6/site-packages/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/venv/lib/python3.6/site-packages/docutils/parsers/rst/states.py
+++ b/venv/lib/python3.6/site-packages/docutils/parsers/rst/states.py
@@ -137,7 +137,7 @@ class Struct:
 class RSTStateMachine(StateMachineWS):
 
     """
-    reStructuredText's master StateMachine.
+    reStructuredText's main StateMachine.
 
     The entry point to reStructuredText parsing is the `run()` method.
     """

--- a/venv/lib/python3.6/site-packages/docutils/parsers/rst/tableparser.py
+++ b/venv/lib/python3.6/site-packages/docutils/parsers/rst/tableparser.py
@@ -534,11 +534,11 @@ class SimpleTableParser(TableParser):
                 self.table[first_body_row:])
 
 
-def update_dict_of_lists(master, newdata):
+def update_dict_of_lists(main, newdata):
     """
-    Extend the list values of `master` with those from `newdata`.
+    Extend the list values of `main` with those from `newdata`.
 
     Both parameters must be dictionaries containing list values.
     """
     for key, values in list(newdata.items()):
-        master.setdefault(key, []).extend(values)
+        main.setdefault(key, []).extend(values)

--- a/venv/lib/python3.6/site-packages/docutils/utils/math/math2html.py
+++ b/venv/lib/python3.6/site-packages/docutils/utils/math/math2html.py
@@ -114,7 +114,7 @@ class BibStylesConfig(object):
       '@incollection':'$authors: <i>$title</i>{ in <i>$booktitle</i>{ ($editor, ed.)}}.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@inproceedings':'$authors: “$title”, <i>$booktitle</i>,{ pp. $pages,} $year.{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@manual':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
-      '@mastersthesis':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
+      '@mainsthesis':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@misc':'$authors: <i>$title</i>.{{ $publisher,}{ $howpublished,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@phdthesis':'$authors: <i>$title</i>.{{ $publisher,} $year.}{ URL <a href="$url">$url</a>.}{ $note.}', 
       '@proceedings':'$authors: “$title”, <i>$journal</i>,{ pp. $pages,} $year.{ URL <a href="$url">$url</a>.}{ $note.}', 
@@ -3177,7 +3177,7 @@ class NumberCounter(object):
   name = None
   value = None
   mode = None
-  master = None
+  main = None
 
   letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
   symbols = NumberingConfig.sequence['symbols']
@@ -3260,25 +3260,25 @@ class NumberCounter(object):
     return result
 
 class DependentCounter(NumberCounter):
-  "A counter which depends on another one (the master)."
+  "A counter which depends on another one (the main)."
 
-  def setmaster(self, master):
-    "Set the master counter."
-    self.master = master
-    self.last = self.master.getvalue()
+  def setmain(self, main):
+    "Set the main counter."
+    self.main = main
+    self.last = self.main.getvalue()
     return self
 
   def getnext(self):
-    "Increase or, if the master counter has changed, restart."
-    if self.last != self.master.getvalue():
+    "Increase or, if the main counter has changed, restart."
+    if self.last != self.main.getvalue():
       self.reset()
     value = NumberCounter.getnext(self)
-    self.last = self.master.getvalue()
+    self.last = self.main.getvalue()
     return value
 
   def getvalue(self):
-    "Get the value of the combined counter: master.dependent."
-    return self.master.getvalue() + '.' + NumberCounter.getvalue(self)
+    "Get the value of the combined counter: main.dependent."
+    return self.main.getvalue() + '.' + NumberCounter.getvalue(self)
 
 class NumberGenerator(object):
   "A number generator for unique sequences and hierarchical structures. Used in:"
@@ -3366,22 +3366,22 @@ class NumberGenerator(object):
     if self.isnumbered(type) and self.getlevel(type) > 1:
       index = self.orderedlayouts.index(type)
       above = self.orderedlayouts[index - 1]
-      master = self.getcounter(above)
-      return self.createdependent(type, master)
+      main = self.getcounter(above)
+      return self.createdependent(type, main)
     counter = NumberCounter(type)
     if self.isroman(type):
       counter.setmode('I')
     return counter
 
-  def getdependentcounter(self, type, master):
+  def getdependentcounter(self, type, main):
     "Get (or create) a counter of the given type that depends on another."
-    if not type in self.counters or not self.counters[type].master:
-      self.counters[type] = self.createdependent(type, master)
+    if not type in self.counters or not self.counters[type].main:
+      self.counters[type] = self.createdependent(type, main)
     return self.counters[type]
 
-  def createdependent(self, type, master):
-    "Create a dependent counter given the master."
-    return DependentCounter(type).setmaster(master)
+  def createdependent(self, type, main):
+    "Create a dependent counter given the main."
+    return DependentCounter(type).setmain(main)
 
   def startappendix(self):
     "Start appendices here."

--- a/venv/lib/python3.6/site-packages/docutils/writers/odf_odt/__init__.py
+++ b/venv/lib/python3.6/site-packages/docutils/writers/odf_odt/__init__.py
@@ -1082,7 +1082,7 @@ class ODFTranslator(nodes.GenericNodeVisitor):
         el1 = SubElement(
             self.automatic_styles, 'style:style', attrib={
                 'style:name': style_name,
-                'style:master-page-name': "rststyle-pagedefault",
+                'style:main-page-name': "rststyle-pagedefault",
                 'style:family': "paragraph",
             }, nsdict=SNSD)
         if current_style:
@@ -1140,22 +1140,22 @@ class ODFTranslator(nodes.GenericNodeVisitor):
     def add_header_footer(self, root_el):
         automatic_styles = root_el.find(
             '{%s}automatic-styles' % SNSD['office'])
-        path = '{%s}master-styles' % (NAME_SPACE_1, )
-        master_el = root_el.find(path)
-        if master_el is None:
+        path = '{%s}main-styles' % (NAME_SPACE_1, )
+        main_el = root_el.find(path)
+        if main_el is None:
             return
-        path = '{%s}master-page' % (SNSD['style'], )
-        master_el_container = master_el.findall(path)
-        master_el = None
+        path = '{%s}main-page' % (SNSD['style'], )
+        main_el_container = main_el.findall(path)
+        main_el = None
         target_attrib = '{%s}name' % (SNSD['style'], )
         target_name = self.rststyle('pagedefault')
-        for el in master_el_container:
+        for el in main_el_container:
             if el.get(target_attrib) == target_name:
-                master_el = el
+                main_el = el
                 break
-        if master_el is None:
+        if main_el is None:
             return
-        el1 = master_el
+        el1 = main_el
         if self.header_content or self.settings.custom_header:
             if WhichElementTree == 'lxml':
                 el2 = SubElement(el1, 'style:header', nsdict=SNSD)

--- a/venv/lib/python3.6/site-packages/gensim/corpora/wikicorpus.py
+++ b/venv/lib/python3.6/site-packages/gensim/corpora/wikicorpus.py
@@ -501,7 +501,7 @@ def init_to_ignore_interrupt():
 
     Warnings
     --------
-    Should only be used when master is prepared to handle termination of
+    Should only be used when main is prepared to handle termination of
     child processes.
 
     """

--- a/venv/lib/python3.6/site-packages/gensim/models/lda_worker.py
+++ b/venv/lib/python3.6/site-packages/gensim/models/lda_worker.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2011 Radim Rehurek <radimrehurek@seznam.cz>
 # Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
 
-"""Worker ("slave") process used in computing distributed Latent Dirichlet Allocation
+"""Worker ("subordinate") process used in computing distributed Latent Dirichlet Allocation
 (LDA, :class:`~gensim.models.ldamodel.LdaModel`).
 
 Run this script on every node in your cluster. If you wish, you may even run it multiple times on a single machine,

--- a/venv/lib/python3.6/site-packages/gensim/models/lsi_worker.py
+++ b/venv/lib/python3.6/site-packages/gensim/models/lsi_worker.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2010 Radim Rehurek <radimrehurek@seznam.cz>
 # Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
 
-"""Worker ("slave") process used in computing distributed Latent Semantic Indexing (LSI,
+"""Worker ("subordinate") process used in computing distributed Latent Semantic Indexing (LSI,
 :class:`~gensim.models.lsimodel.LsiModel`) models.
 
 Run this script on every node in your cluster. If you wish, you may even run it multiple times on a single machine,

--- a/venv/lib/python3.6/site-packages/gensim/test/test_nmf.py
+++ b/venv/lib/python3.6/site-packages/gensim/test/test_nmf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 Timofey Yefimov <anotherbugmaster@gmail.com>
+# Copyright (C) 2018 Timofey Yefimov <anotherbugmain@gmail.com>
 # Licensed under the GNU LGPL v2.1 - http://www.gnu.org/licenses/lgpl.html
 
 """

--- a/venv/lib/python3.6/site-packages/gensim/topic_coherence/text_analysis.py
+++ b/venv/lib/python3.6/site-packages/gensim/topic_coherence/text_analysis.py
@@ -409,9 +409,9 @@ class WordOccurrenceAccumulator(WindowedTextsAnalyzer):
 
 
 class PatchedWordOccurrenceAccumulator(WordOccurrenceAccumulator):
-    """Monkey patched for multiprocessing worker usage, to move some of the logic to the master process."""
+    """Monkey patched for multiprocessing worker usage, to move some of the logic to the main process."""
     def _iter_texts(self, texts):
-        return texts  # master process will handle this
+        return texts  # main process will handle this
 
 
 class ParallelWordOccurrenceAccumulator(WindowedTextsAnalyzer):
@@ -574,7 +574,7 @@ class AccumulatingWorker(mp.Process):
         except Exception:
             logger.exception("worker encountered unexpected exception")
         finally:
-            self.reply_to_master()
+            self.reply_to_main()
 
     def _run(self):
         batch_num = -1
@@ -596,8 +596,8 @@ class AccumulatingWorker(mp.Process):
             "finished all batches; %d documents processed (%d virtual)",
             n_docs, self.accumulator.num_docs)
 
-    def reply_to_master(self):
-        logger.info("serializing accumulator to return to master...")
+    def reply_to_main(self):
+        logger.info("serializing accumulator to return to main...")
         self.output_q.put(self.accumulator, block=False)
         logger.info("accumulator serialized")
 

--- a/venv/lib/python3.6/site-packages/joblib/externals/loky/process_executor.py
+++ b/venv/lib/python3.6/site-packages/joblib/externals/loky/process_executor.py
@@ -449,7 +449,7 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
                     # The GC managed to free the memory: everything is fine.
                     continue
 
-                # The process is leaking memory: let the master process
+                # The process is leaking memory: let the main process
                 # know that we need to start a new worker.
                 mp.util.info("Memory leak detected: shutting down worker")
                 result_queue.put(pid)

--- a/venv/lib/python3.6/site-packages/joblib/pool.py
+++ b/venv/lib/python3.6/site-packages/joblib/pool.py
@@ -263,11 +263,11 @@ class MemmappingPool(PicklingPool):
         Memmapping mode for numpy arrays passed to workers.
         See 'max_nbytes' parameter documentation for more details.
     forward_reducers: dictionary, optional
-        Reducers used to pickle objects passed from master to worker
+        Reducers used to pickle objects passed from main to worker
         processes: see below.
     backward_reducers: dictionary, optional
         Reducers used to pickle return values from workers back to the
-        master process.
+        main process.
     verbose: int, optional
         Make it possible to monitor how the communication of numpy arrays
         with the subprocess is handled (pickling or memmapping)

--- a/venv/lib/python3.6/site-packages/joblib/test/common.py
+++ b/venv/lib/python3.6/site-packages/joblib/test/common.py
@@ -60,7 +60,7 @@ except ImportError:
     memory_usage = memory_used = None
 
 # A utility to kill the test runner in case a multiprocessing assumption
-# triggers an infinite wait on a pipe by the master process for one of its
+# triggers an infinite wait on a pipe by the main process for one of its
 # failed workers
 
 _KILLER_THREADS = dict()

--- a/venv/lib/python3.6/site-packages/nltk/corpus/reader/timit.py
+++ b/venv/lib/python3.6/site-packages/nltk/corpus/reader/timit.py
@@ -85,7 +85,7 @@ The timit corpus reader provides 4 functions and 4 data items.
      race       speaker race (WHT:white, BLK:black, AMR:american indian,
                 SPN:spanish-american, ORN:oriental,???:unknown)
      edu        speaker education level (HS:high school, AS:associate degree,
-                BS:bachelor's degree (BS or BA), MS:master's degree (MS or MA),
+                BS:bachelor's degree (BS or BA), MS:main's degree (MS or MA),
                 PHD:doctorate degree (PhD,JD,MD), ??:unknown)
      comments   comments by the recorder
 

--- a/venv/lib/python3.6/site-packages/nltk/draw/table.py
+++ b/venv/lib/python3.6/site-packages/nltk/draw/table.py
@@ -64,11 +64,11 @@ class MultiListbox(Frame):
     # Constructor
     # /////////////////////////////////////////////////////////////////
 
-    def __init__(self, master, columns, column_weights=None, cnf={}, **kw):
+    def __init__(self, main, columns, column_weights=None, cnf={}, **kw):
         """
         Construct a new multi-column listbox widget.
 
-        :param master: The widget that should contain the new
+        :param main: The widget that should contain the new
             multi-column listbox.
 
         :param columns: Specifies what columns should be included in
@@ -82,7 +82,7 @@ class MultiListbox(Frame):
             Use ``label_*`` to configure all labels; and ``listbox_*``
             to configure all listboxes.  E.g.:
 
-                >>> mlb = MultiListbox(master, 5, label_foreground='red')
+                >>> mlb = MultiListbox(main, 5, label_foreground='red')
         """
         # If columns was specified as an int, convert it to a list.
         if isinstance(columns, int):
@@ -107,7 +107,7 @@ class MultiListbox(Frame):
         self._column_weights = column_weights
 
         # Configure our widgets.
-        Frame.__init__(self, master, **self.FRAME_CONFIG)
+        Frame.__init__(self, main, **self.FRAME_CONFIG)
         self.grid_rowconfigure(1, weight=1)
         for i, label in enumerate(self._column_names):
             self.grid_columnconfigure(i, weight=column_weights[i])
@@ -305,7 +305,7 @@ class MultiListbox(Frame):
         Configure this widget.  Use ``label_*`` to configure all
         labels; and ``listbox_*`` to configure all listboxes.  E.g.:
 
-                >>> mlb = MultiListbox(master, 5)
+                >>> mlb = MultiListbox(main, 5)
                 >>> mlb.configure(label_foreground='red')
                 >>> mlb.configure(listbox_foreground='red')
         """
@@ -623,7 +623,7 @@ class Table(object):
 
     def __init__(
         self,
-        master,
+        main,
         column_names,
         rows=None,
         column_weights=None,
@@ -636,8 +636,8 @@ class Table(object):
         """
         Construct a new Table widget.
 
-        :type master: Tkinter.Widget
-        :param master: The widget that should contain the new table.
+        :type main: Tkinter.Widget
+        :param main: The widget that should contain the new table.
         :type column_names: list(str)
         :param column_names: A list of names for the columns; these
             names will be used to create labels for each column;
@@ -666,7 +666,7 @@ class Table(object):
         """
         self._num_columns = len(column_names)
         self._reprfunc = reprfunc
-        self._frame = Frame(master)
+        self._frame = Frame(main)
 
         self._column_name_to_index = dict((c, i) for (i, c) in enumerate(column_names))
 

--- a/venv/lib/python3.6/site-packages/nltk/draw/util.py
+++ b/venv/lib/python3.6/site-packages/nltk/draw/util.py
@@ -2451,7 +2451,7 @@ class ColorizedList(object):
 
 
 class MutableOptionMenu(Menubutton):
-    def __init__(self, master, values, **options):
+    def __init__(self, main, values, **options):
         self._callback = options.get('command')
         if 'command' in options:
             del options['command']
@@ -2470,7 +2470,7 @@ class MutableOptionMenu(Menubutton):
             "highlightthickness": 2,
         }
         kw.update(options)
-        Widget.__init__(self, master, "menubutton", kw)
+        Widget.__init__(self, main, "menubutton", kw)
         self.widgetName = 'tk_optionMenu'
         self._menu = Menu(self, name="menu", tearoff=0)
         self.menuname = self._menu._w

--- a/venv/lib/python3.6/site-packages/nltk/featstruct.py
+++ b/venv/lib/python3.6/site-packages/nltk/featstruct.py
@@ -2678,7 +2678,7 @@ def interactive_demo(trace=False):
         print()
 
     while True:
-        # Pick 5 feature structures at random from the master list.
+        # Pick 5 feature structures at random from the main list.
         MAX_CHOICES = 5
         if len(all_fstructs) > MAX_CHOICES:
             fstructs = sorted(random.sample(all_fstructs, MAX_CHOICES))

--- a/venv/lib/python3.6/site-packages/nltk/misc/chomsky.py
+++ b/venv/lib/python3.6/site-packages/nltk/misc/chomsky.py
@@ -3,7 +3,7 @@
 
 """
 CHOMSKY is an aid to writing linguistic papers in the style
-of the great master.  It is based on selected phrases taken
+of the great main.  It is based on selected phrases taken
 from actual books and articles written by Noam Chomsky.
 Upon request, it assembles the phrases in the elegant
 stylistic patterns that Chomsky is noted for.

--- a/venv/lib/python3.6/site-packages/nltk/sem/drt.py
+++ b/venv/lib/python3.6/site-packages/nltk/sem/drt.py
@@ -1104,31 +1104,31 @@ class DrsDrawer(object):
         :param size_canvas: bool, True if the canvas size should be the exact size of the DRS
         :param canvas: ``Canvas`` The canvas on which to draw the DRS.  If none is given, create a new canvas.
         """
-        master = None
+        main = None
         if not canvas:
-            master = Tk()
-            master.title("DRT")
+            main = Tk()
+            main.title("DRT")
 
             font = Font(family='helvetica', size=12)
 
             if size_canvas:
-                canvas = Canvas(master, width=0, height=0)
+                canvas = Canvas(main, width=0, height=0)
                 canvas.font = font
                 self.canvas = canvas
                 (right, bottom) = self._visit(drs, self.OUTERSPACE, self.TOPSPACE)
 
                 width = max(right + self.OUTERSPACE, 100)
                 height = bottom + self.OUTERSPACE
-                canvas = Canvas(master, width=width, height=height)  # , bg='white')
+                canvas = Canvas(main, width=width, height=height)  # , bg='white')
             else:
-                canvas = Canvas(master, width=300, height=300)
+                canvas = Canvas(main, width=300, height=300)
 
             canvas.pack()
             canvas.font = font
 
         self.canvas = canvas
         self.drs = drs
-        self.master = master
+        self.main = main
 
     def _get_text_height(self):
         """Get the height of a line of text"""
@@ -1138,8 +1138,8 @@ class DrsDrawer(object):
         """Draw the DRS"""
         self._handle(self.drs, self._draw_command, x, y)
 
-        if self.master and not in_idle():
-            self.master.mainloop()
+        if self.main and not in_idle():
+            self.main.mainloop()
         else:
             return self._visit(self.drs, x, y)
 

--- a/venv/lib/python3.6/site-packages/nltk/sem/logic.py
+++ b/venv/lib/python3.6/site-packages/nltk/sem/logic.py
@@ -917,10 +917,10 @@ def typecheck(expressions, signature=None):
     :param signature: dict that maps variable names to types (or string
     representations of types)
     """
-    # typecheck and create master signature
+    # typecheck and create main signature
     for expression in expressions:
         signature = expression.typecheck(signature)
-    # apply master signature to all expressions
+    # apply main signature to all expressions
     for expression in expressions[:-1]:
         expression.typecheck(signature)
     return signature

--- a/venv/lib/python3.6/site-packages/numpy/distutils/system_info.py
+++ b/venv/lib/python3.6/site-packages/numpy/distutils/system_info.py
@@ -109,7 +109,7 @@ Note that the ``libraries`` key is the default setting for libraries.
 
 Authors:
   Pearu Peterson <pearu@cens.ioc.ee>, February 2002
-  David M. Cooke <cookedm@physics.mcmaster.ca>, April 2002
+  David M. Cooke <cookedm@physics.mcmain.ca>, April 2002
 
 Copyright 2002 Pearu Peterson all rights reserved,
 Pearu Peterson <pearu@cens.ioc.ee>

--- a/venv/lib/python3.6/site-packages/numpy/testing/_private/nosetester.py
+++ b/venv/lib/python3.6/site-packages/numpy/testing/_private/nosetester.py
@@ -414,7 +414,7 @@ class NoseTester(object):
 
         # reset doctest state on every run
         import doctest
-        doctest.master = None
+        doctest.main = None
 
         if raise_warnings is None:
             raise_warnings = self.raise_warnings

--- a/venv/lib/python3.6/site-packages/pandas/io/pytables.py
+++ b/venv/lib/python3.6/site-packages/pandas/io/pytables.py
@@ -2658,7 +2658,7 @@ class GenericFixed(Fixed):
 
     def _alias_to_class(self, alias):
         if isinstance(alias, type):  # pragma: no cover
-            # compat: for a short period of time master stored types
+            # compat: for a short period of time main stored types
             return alias
         return self._reverse_index_map.get(alias, Index)
 

--- a/venv/lib/python3.6/site-packages/pandas/io/sql.py
+++ b/venv/lib/python3.6/site-packages/pandas/io/sql.py
@@ -1756,7 +1756,7 @@ class SQLiteDatabase(PandasSQL):
 
         wld = "?"
         query = (
-            "SELECT name FROM sqlite_master " "WHERE type='table' AND name={wld};"
+            "SELECT name FROM sqlite_main " "WHERE type='table' AND name={wld};"
         ).format(wld=wld)
 
         return len(self.execute(query, [name]).fetchall()) > 0

--- a/venv/lib/python3.6/site-packages/pandas/tests/io/excel/test_readers.py
+++ b/venv/lib/python3.6/site-packages/pandas/tests/io/excel/test_readers.py
@@ -500,7 +500,7 @@ class TestReaders:
 
     @tm.network
     def test_read_from_http_url(self, read_ext):
-        if read_ext == ".ods":  # TODO: remove once on master
+        if read_ext == ".ods":  # TODO: remove once on main
             pytest.skip()
 
         url = (

--- a/venv/lib/python3.6/site-packages/pandas/tests/io/generate_legacy_storage_files.py
+++ b/venv/lib/python3.6/site-packages/pandas/tests/io/generate_legacy_storage_files.py
@@ -25,7 +25,7 @@ generate_legacy_storage_files with an *older* version of pandas to
 generate a pickle file. We will then check this file into a current
 branch, and test using test_pickle.py. This will load the *older*
 pickles and test versus the current data that is generated
-(with master). These are then compared.
+(with main). These are then compared.
 
 If we have cases where we changed the signature (e.g. we renamed
 offset -> freq in Timestamp). Then we have to conditionally execute

--- a/venv/lib/python3.6/site-packages/pandas/tests/io/test_sql.py
+++ b/venv/lib/python3.6/site-packages/pandas/tests/io/test_sql.py
@@ -244,7 +244,7 @@ class SQLiteMixIn(MixInBase):
         self.conn.commit()
 
     def _get_all_tables(self):
-        c = self.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        c = self.conn.execute("SELECT name FROM sqlite_main WHERE type='table'")
         return [table[0] for table in c.fetchall()]
 
     def _close_conn(self):
@@ -2198,7 +2198,7 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
 
     def _get_index_columns(self, tbl_name):
         ixs = sql.read_sql_query(
-            "SELECT * FROM sqlite_master WHERE type = 'index' "
+            "SELECT * FROM sqlite_main WHERE type = 'index' "
             + "AND tbl_name = '{tbl_name}'".format(tbl_name=tbl_name),
             self.conn,
         )

--- a/venv/lib/python3.6/site-packages/pip-19.0.3-py3.6.egg/pip/_internal/vcs/git.py
+++ b/venv/lib/python3.6/site-packages/pip-19.0.3-py3.6.egg/pip/_internal/vcs/git.py
@@ -242,7 +242,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         rev_options = self.resolve_revision(dest, url, rev_options)
         cmd_args = ['reset', '--hard', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)

--- a/venv/lib/python3.6/site-packages/pip-19.0.3-py3.6.egg/pip/_vendor/pkg_resources/__init__.py
+++ b/venv/lib/python3.6/site-packages/pip-19.0.3-py3.6.egg/pip/_vendor/pkg_resources/__init__.py
@@ -565,9 +565,9 @@ class WorkingSet:
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3124,9 +3124,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3136,7 +3136,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/venv/lib/python3.6/site-packages/scipy/optimize/lbfgsb.py
+++ b/venv/lib/python3.6/site-packages/scipy/optimize/lbfgsb.py
@@ -11,7 +11,7 @@ Functions
 ## License for the Python wrapper
 ## ==============================
 
-## Copyright (c) 2004 David M. Cooke <cookedm@physics.mcmaster.ca>
+## Copyright (c) 2004 David M. Cooke <cookedm@physics.mcmain.ca>
 
 ## Permission is hereby granted, free of charge, to any person obtaining a
 ## copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.